### PR TITLE
fix: wrap ws.close in asyncio.create_task

### DIFF
--- a/outspeed/plugins/cartesia_tts.py
+++ b/outspeed/plugins/cartesia_tts.py
@@ -215,7 +215,8 @@ class CartesiaTTS(Plugin):
     async def close(self):
         """Close the websocket connection and cancel the main task."""
         if self._ws:
-            await self._ws.close()
+            asyncio.create_task(self._ws.close())
+
         if self._task:
             self._task.cancel()
 


### PR DESCRIPTION
- do this because we don't care about errors during close